### PR TITLE
PEP 639 compliance with license-file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "sequence_align"
-version = "0.1.0"
+version = "0.1.1"
 description = "Efficient implementations of Needleman-Wunsch and other sequence alignment algorithms in Rust with Python bindings."
 readme = "README.md"
 requires-python = ">=3.7"
@@ -15,9 +15,8 @@ maintainers = [
     {name = "Kensho Technologies LLC.", email = "sequence-align-maintainer@kensho.com"},
 ]
 # Apache 2.0
-license = {file = "LICENSE"}
+license-file = "LICENSE"
 classifiers = [
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",

--- a/tests/perf/expected_perf.yml
+++ b/tests/perf/expected_perf.yml
@@ -12,8 +12,8 @@ needleman_wunsch:
 hirschberg:
   runtime:
     # Generally more sensitive to machine/environment
-    median: 0.50  # Seconds
-    tolerance: 0.50  # +/- 50% (0.25 - 0.75s)
+    median: 0.375  # Seconds
+    tolerance: 0.50  # +/- 50% (0.1875 - 0.5625s)
   memory:
     # More consistent, but low enough to have major percent-wise variation
     median: 32.0  # MiB


### PR DESCRIPTION
See https://peps.python.org/pep-0639/#deprecate-license-field. This removes the now-deprecated `license` field and license classifiers, and replaces it with `license-file`.