### PR TITLE
Fix broken 0.1.1 wheels and LICENSE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ docs/_build/
 # mypy
 .mypy_cache/
 
+# Wheels directory for upload to PyPI
+wheels/
+
 
 # RUST
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"
 
 [project]
@@ -14,8 +14,9 @@ authors = [
 maintainers = [
     {name = "Kensho Technologies LLC.", email = "sequence-align-maintainer@kensho.com"},
 ]
-# Apache 2.0
-license-file = "LICENSE"
+license-files.paths = [
+    "LICENSE",  # Apache 2.0
+]
 classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.7",
@@ -55,6 +56,9 @@ dev = [
 line-length = 100
 
 [tool.maturin]
+# See https://www.maturin.rs/project_layout.html#import-rust-as-a-submodule-of-your-project
+# Allows "from sequence_align import _sequence_align" import
+module-name = "sequence_align._sequence_align"
 # "extension-module" tells pyo3 we want to build an extension module (skips linking against libpython.so)
 features = ["pyo3/extension-module"]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "sequence_align"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
-license-file = "../LICENSE"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
@@ -10,13 +10,9 @@ name = "sequence_align"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3]
-version = "0.18.0"
+version = "0.20.0"
 # "abi3-py37" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.7
 features = ["abi3-py37"]
-
-# See https://www.maturin.rs/project_layout.html#alternate-python-source-directory-src-layout
-[package.metadata.maturin]
-name = "sequence_align._sequence_align"
 
 # Some additional optimizations; see https://deterministic.space/high-performance-rust.html
 [profile.release]


### PR DESCRIPTION
Seems like we had duplicate licenses from https://github.com/pypa/setuptools/issues/2739 (resolved by changing Cargo.TOML to refer to Apache 2.0 license directly) and issues with the underlying `sequence_align._sequence_align` import from Maturin updating. Fixed both here and will republish new versions of wheels as the current 0.1.1 ones are DOA.